### PR TITLE
Implement phrase search and nested grouping

### DIFF
--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -12,19 +12,22 @@ abstract class Query {
 }
 
 /// Text query to match [text].
+///
+/// [isExactMatch] is set when the [text] was inside quotes.
 class TextQuery implements Query {
   final String text;
-  TextQuery(this.text);
+  final bool isExactMatch;
+  TextQuery(this.text, {this.isExactMatch = false});
 
   @override
-  String toString({bool debug = false}) => _debug(debug, text);
+  String toString({bool debug = false}) =>
+      _debug(debug, isExactMatch ? '"$text"' : text);
 }
 
 /// Phrase query to match "[text]" for a list of words inside quotes.
 class PhraseQuery extends TextQuery {
   final List<TextQuery> children;
-  PhraseQuery(this.children)
-      : super(children.isEmpty ? '""' : '"${children.join(" ")}"');
+  PhraseQuery(String phrase, this.children) : super(phrase, isExactMatch: true);
 
   @override
   String toString({bool debug = false}) =>

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -79,6 +79,15 @@ class NotQuery implements Query {
   String toString({bool debug = false}) => '-${child.toString(debug: debug)}';
 }
 
+/// Groups the [child] query to override implicit precedence.
+class GroupQuery implements Query {
+  final Query child;
+  GroupQuery(this.child);
+
+  @override
+  String toString({bool debug = false}) => '(${child.toString(debug: debug)})';
+}
+
 /// Bool AND composition of [children] queries.
 class AndQuery implements Query {
   final List<Query> children;

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -12,16 +12,23 @@ abstract class Query {
 }
 
 /// Text query to match [text].
-///
-/// [isExactMatch] is set when the [text] was inside quotes.
 class TextQuery implements Query {
   final String text;
-  final bool isExactMatch;
-  TextQuery(this.text, {this.isExactMatch = false});
+  TextQuery(this.text);
+
+  @override
+  String toString({bool debug = false}) => _debug(debug, text);
+}
+
+/// Phrase query to match "[text]" for a list of words inside quotes.
+class PhraseQuery extends TextQuery {
+  final List<TextQuery> children;
+  PhraseQuery(this.children)
+      : super(children.isEmpty ? '""' : '"${children.join(" ")}"');
 
   @override
   String toString({bool debug = false}) =>
-      _debug(debug, isExactMatch ? '"$text"' : text);
+      '"' + children.map((n) => n.toString(debug: debug)).join(' ') + '"';
 }
 
 /// Scopes [child] [Query] to be applied only on the [field].

--- a/lib/src/grammar.dart
+++ b/lib/src/grammar.dart
@@ -30,7 +30,9 @@ class QueryGrammarDefinition extends GrammarDefinition {
   // Handles <exp> OR <exp> sequences.
   Parser<Query> or() {
     final g = ref(scopedExpression) &
-        (string(' OR ') & ref(root)).map((list) => list.last).star();
+        ((string(' | ') | string(' OR ')) & ref(root))
+            .map((list) => list.last)
+            .star();
     return g.map((list) {
       final children = <Query>[list.first as Query]
         ..addAll((list.last as List).cast<Query>());

--- a/lib/src/grammar.dart
+++ b/lib/src/grammar.dart
@@ -109,10 +109,14 @@ class QueryGrammarDefinition extends GrammarDefinition {
         char('"');
     return g.map((list) {
       final children = <TextQuery>[];
+      var phrase = list[1].join() as String;
       for (var w in list[2]) {
-        children.add(TextQuery((w.first as List).join()));
+        var word = w.first.join() as String;
+        var sep = w[1].join() as String;
+        phrase += '${word}${sep}';
+        children.add(TextQuery(word));
       }
-      return PhraseQuery(children);
+      return PhraseQuery(phrase, children);
     });
   }
 

--- a/lib/src/grammar.dart
+++ b/lib/src/grammar.dart
@@ -105,12 +105,12 @@ class QueryGrammarDefinition extends GrammarDefinition {
   Parser exact() {
     final g = char('"') &
         ref(EXP_SEP).star() &
-        (ref(WORD) & ref(EXP_SEP).star()).star() &
+        (pattern('^" \t\n\r').plus() & ref(EXP_SEP).star()).star() &
         char('"');
     return g.map((list) {
       final children = <TextQuery>[];
       for (var w in list[2]) {
-        children.add(w.first as TextQuery);
+        children.add(TextQuery((w.first as List).join()));
       }
       return PhraseQuery(children);
     });

--- a/lib/src/grammar.dart
+++ b/lib/src/grammar.dart
@@ -103,9 +103,17 @@ class QueryGrammarDefinition extends GrammarDefinition {
   Parser wordOrExact() => ref(exact) | ref(WORD);
 
   Parser exact() {
-    final g = char('"') & pattern('^"').plus() & char('"');
-    return g
-        .map((list) => TextQuery((list[1] as List).join(), isExactMatch: true));
+    final g = char('"') &
+        ref(EXP_SEP).star() &
+        (ref(WORD) & ref(EXP_SEP).star()).star() &
+        char('"');
+    return g.map((list) {
+      final children = <TextQuery>[];
+      for (var w in list[2]) {
+        children.add(w.first as TextQuery);
+      }
+      return PhraseQuery(children);
+    });
   }
 
   Parser<String> EXP_SEP() => WORD_SEP();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  petitparser: ^2.0.0
+  petitparser: ^3.0.0
 
 dev_dependencies:
   pedantic: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: query
 description: >
   Search query parser to implement customized search.
   Supports boolean groups, field scopes, ranges, comparisons...
-version: 1.2.0
+version: 1.3.0
 homepage: https://github.com/isoos/query
 author: Istvan Soos <istvan.soos@gmail.com>
 

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -8,16 +8,16 @@ void main() {
   group('Base expressions', () {
     test('1 string', () {
       expect(debugQuery('abc'), '<abc>');
-      expect(debugQuery('"abc"'), '<"abc">');
+      expect(debugQuery('"abc"'), '"<abc>"');
       expect(debugQuery('abc*'), '<abc*>');
     });
 
     test('2 strings', () {
       expect(debugQuery('abc def'), '(<abc> <def>)');
-      expect(debugQuery('"abc 1" def'), '(<"abc 1"> <def>)');
-      expect(debugQuery('abc "def 2"'), '(<abc> <"def 2">)');
-      expect(debugQuery('"abc" "def"'), '(<"abc"> <"def">)');
-      expect(debugQuery('"abc 1" "def 2"'), '(<"abc 1"> <"def 2">)');
+      expect(debugQuery('"abc 1" def'), '("<abc> <1>" <def>)');
+      expect(debugQuery('abc "def 2"'), '(<abc> "<def> <2>")');
+      expect(debugQuery('"abc" "def"'), '("<abc>" "<def>")');
+      expect(debugQuery('"abc 1" "def 2"'), '("<abc> <1>" "<def> <2>")');
     });
 
     test('explicit AND', () {
@@ -26,24 +26,24 @@ void main() {
 
     test('negative word', () {
       expect(debugQuery('-abc'), '-<abc>');
-      expect(debugQuery('-"abc"'), '-<"abc">');
-      expect(debugQuery('-"abc 1"'), '-<"abc 1">');
+      expect(debugQuery('-"abc"'), '-"<abc>"');
+      expect(debugQuery('-"abc 1"'), '-"<abc> <1>"');
 
       expect(debugQuery('NOT abc'), '-<abc>');
-      expect(debugQuery('NOT "abc"'), '-<"abc">');
-      expect(debugQuery('NOT "abc 1"'), '-<"abc 1">');
+      expect(debugQuery('NOT "abc"'), '-"<abc>"');
+      expect(debugQuery('NOT "abc 1"'), '-"<abc> <1>"');
     });
 
     test('scoped', () {
       expect(debugQuery('a:abc'), 'a:<abc>');
-      expect(debugQuery('a:"abc"'), 'a:<"abc">');
-      expect(debugQuery('a:"abc 1"'), 'a:<"abc 1">');
-      expect(debugQuery('a:-"abc 1"'), 'a:-<"abc 1">');
+      expect(debugQuery('a:"abc"'), 'a:"<abc>"');
+      expect(debugQuery('a:"abc 1"'), 'a:"<abc> <1>"');
+      expect(debugQuery('a:-"abc 1"'), 'a:-"<abc> <1>"');
     });
 
     test('special scoped', () {
       expect(debugQuery('a*:abc'), 'a*:<abc>');
-      expect(debugQuery('a%:"abc"'), 'a%:<"abc">');
+      expect(debugQuery('a%:"abc"'), 'a%:"<abc>"');
     });
 
     test('compare', () {
@@ -54,7 +54,7 @@ void main() {
     test('range', () {
       expect(debugQuery('[1 TO 10]'), '<[<1> TO <10>]>');
       expect(debugQuery(']1 TO 10['), '<]<1> TO <10>[>');
-      expect(debugQuery(']"1 a" TO "10 b"['), '<]<"1 a"> TO <"10 b">[>');
+      expect(debugQuery(']"1 a" TO "10 b"['), '<]"<1> <a>" TO "<10> <b>"[>');
     });
   });
 
@@ -138,6 +138,33 @@ void main() {
       expect(debugQuery('(a OR b) OR c'), '(((<a> OR <b>)) OR <c>)');
       expect(debugQuery('(a OR b) c'), '(((<a> OR <b>)) <c>)');
       expect(debugQuery('((a OR b) c) | d'), '(((((<a> OR <b>)) <c>)) OR <d>)');
+    });
+  });
+
+  group('phrase match', () {
+    test('empty phrase', () {
+      expect(debugQuery('""'), '""');
+    });
+    test('empty phrase with space', () {
+      expect(debugQuery('"  "'), '""');
+    });
+    test('simple word phrase', () {
+      expect(debugQuery('"a"'), '"<a>"');
+    });
+    test('single word phrase with space', () {
+      expect(debugQuery('" a "'), '"<a>"');
+    });
+    test('two word phrase', () {
+      expect(debugQuery('"a b"'), '"<a> <b>"');
+    });
+    test('three word phrase', () {
+      expect(debugQuery('"a b c"'), '"<a> <b> <c>"');
+    });
+    test('three word phrase with AND', () {
+      expect(debugQuery('"a AND b"'), '"<a> <AND> <b>"');
+    });
+    test('three word phrase with OR', () {
+      expect(debugQuery('"a OR b"'), '"<a> <OR> <b>"');
     });
   });
 }

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -139,6 +139,12 @@ void main() {
       expect(debugQuery('(a OR b) c'), '(((<a> OR <b>)) <c>)');
       expect(debugQuery('((a OR b) c) | d'), '(((((<a> OR <b>)) <c>)) OR <d>)');
     });
+    test('negative grouping', () {
+      expect(debugQuery('-(a OR b) OR c'), '(-((<a> OR <b>)) OR <c>)');
+      expect(debugQuery('(a OR -b) c'), '(((<a> OR -<b>)) <c>)');
+      expect(debugQuery('-(-(a OR -b) -c) | -(d)'),
+          '(-((-((<a> OR -<b>)) -<c>)) OR -(<d>))');
+    });
   });
 
   group('phrase match', () {
@@ -165,6 +171,12 @@ void main() {
     });
     test('three word phrase with OR', () {
       expect(debugQuery('"a OR b"'), '"<a> <OR> <b>"');
+    });
+    test('negative phrase grouping', () {
+      expect(debugQuery('-("a OR b") OR c'), '(-("<a> <OR> <b>") OR <c>)');
+      expect(debugQuery('(a OR -"b") ("c")'), '(((<a> OR -"<b>")) ("<c>"))');
+      expect(debugQuery('-(-"a OR -b" -c) | -"d"'),
+          '(-((-"<a> <OR> <-b>" -<c>)) OR -"<d>")');
     });
   });
 }

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -178,5 +178,9 @@ void main() {
       expect(debugQuery('-(-"a OR -b" -c) | -"d"'),
           '(-((-"<a> <OR> <-b>" -<c>)) OR -"<d>")');
     });
+    test('phrase with parenthesis', () {
+      expect(debugQuery('"(a OR -b)" -("-c | []")'),
+          '("<(a> <OR> <-b)>" -("<-c> <|> <[]>"))');
+    });
   });
 }

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -62,14 +62,33 @@ void main() {
       expect(debugQuery('a OR b'), '(<a> OR <b>)');
     });
 
+    test('2 items pipe', () {
+      expect(debugQuery('a | b'), '(<a> OR <b>)');
+    });
+
     test('3 items', () {
       expect(debugQuery('a OR b OR c'), '(<a> OR <b> OR <c>)');
+    });
+
+    test('3 items pipe', () {
+      expect(debugQuery('a | b | c'), '(<a> OR <b> OR <c>)');
+    });
+
+    test('3 items pipe mixed', () {
+      expect(debugQuery('a OR b | c'), '(<a> OR <b> OR <c>)');
+      expect(debugQuery('a | b OR c'), '(<a> OR <b> OR <c>)');
     });
 
     test('precedence of implicit AND, explicit OR', () {
       expect(debugQuery('a b OR c'), '(<a> (<b> OR <c>))');
       expect(debugQuery('a OR b c'), '(<a> OR (<b> <c>))');
       expect(debugQuery('a OR b c OR d'), '(<a> OR (<b> (<c> OR <d>)))');
+    });
+
+    test('precedence of implicit AND, explicit OR pipe', () {
+      expect(debugQuery('a b | c'), '(<a> (<b> OR <c>))');
+      expect(debugQuery('a | b c'), '(<a> OR (<b> <c>))');
+      expect(debugQuery('a | b c | d'), '(<a> OR (<b> (<c> OR <d>)))');
     });
   });
 

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -1,4 +1,5 @@
 import 'package:query/query.dart';
+import 'package:petitparser/petitparser.dart';
 import 'package:test/test.dart';
 
 String debugQuery(String input) => parseQuery(input).toString(debug: true);
@@ -95,7 +96,7 @@ void main() {
   group('complex cases', () {
     test('#1', () {
       expect(debugQuery('a:-v1 b:(beta OR moon < Deimos OR [a TO e])'),
-          '(a:-<v1> b:(<beta> OR <moon<Deimos> OR <[<a> TO <e>]>))');
+          '(a:-<v1> b:((<beta> OR <moon<Deimos> OR <[<a> TO <e>]>)))');
     });
 
     test('#2', () {
@@ -107,6 +108,36 @@ void main() {
     test('hungarian', () {
       expect(
           debugQuery('árvíztűrő TÜKÖRFÚRÓGÉP'), '(<árvíztűrő> <TÜKÖRFÚRÓGÉP>)');
+    });
+  });
+
+  group('grouping precedence', () {
+    test('empty group', () {
+      expect(debugQuery('()'), '(<>)');
+    });
+    test('empty group with space', () {
+      expect(debugQuery('(  )'), '(<>)');
+    });
+    test('single item group', () {
+      expect(debugQuery('(a)'), '(<a>)');
+    });
+    test('single item group with space', () {
+      expect(debugQuery('( a )'), '(<a>)');
+    });
+    test('grouping with two items implicit AND', () {
+      expect(debugQuery('(a b)'), '((<a> <b>))');
+    });
+    test('grouping with two items explicit AND', () {
+      expect(debugQuery('(a AND b)'), '((<a> <b>))');
+    });
+    test('grouping with multiple items', () {
+      expect(debugQuery('(a | b) c (d | e)'),
+          '(((<a> OR <b>)) <c> ((<d> OR <e>)))');
+    });
+    test('nested grouping', () {
+      expect(debugQuery('(a OR b) OR c'), '(((<a> OR <b>)) OR <c>)');
+      expect(debugQuery('(a OR b) c'), '(((<a> OR <b>)) <c>)');
+      expect(debugQuery('((a OR b) c) | d'), '(((((<a> OR <b>)) <c>)) OR <d>)');
     });
   });
 }


### PR DESCRIPTION
I mainly did 3 changes:
1. Bump the version for petitparser to 3. (No changes were needed)
2  Implement phrase search that instead of treating everything inside quotes as a string, breaking it into a list of TextQuery.
3. Implement nested grouping using parentheses.