### PR TITLE
Add tokenStart and tokenEnd to query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Breaking changes**
 - `FieldScope.field`, `FieldCompareQuery.field` and `FieldCompareQuery.operator` are now a `TextQuery`.
 - `field:<exp>` and `field <operator> <exp>`: `<exp>` can now be an empty string.
+- `TextQuery.isExact` and `PhraseQuery.isExact` are removed. `PhraseQuery` is always exact and `TextQuery` never is.
 
 **Updated**
 - Added `SourcePosition` to `Query`, storing the `start` and `end` index of the matching input.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## 2.0.0
 
-- __Breaking__: `FieldScope.field`, `FieldCompareQuery.field` and `FieldCompareQuery.operator` are now a `TextQuery`.
-- __Breaking__: `field:<exp>` and `field <operator> <exp>`: `<exp>` can now be an empty string.
-- Added `startIndex` and `endIndex` to `Query`.
+**Breaking changes**
+- `FieldScope.field`, `FieldCompareQuery.field` and `FieldCompareQuery.operator` are now a `TextQuery`.
+- `field:<exp>` and `field <operator> <exp>`: `<exp>` can now be an empty string.
+
+**Updated**
+- Added `SourcePosition` to `Query`, storing the `start` and `end` index of the matching input.
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 2.0.0
 
+- __Breaking__: `FieldScope.field`, `FieldCompareQuery.field` and `FieldCompareQuery.operator` are now a `TextQuery`.
+- __Breaking__: `field:<exp>` and `field <operator> <exp>`: `<exp>` can now be an empty string.
 - Added `startIndex` and `endIndex` to `Query`.
-- `FieldScope.field`, `FieldCompareQuery.field` and `FieldCompareQuery.operator` are now a `TextQuery`.
-- `field:<exp>` and `field <operator> <exp>`: `<exp>` can now be an empty string.
 
 ## 1.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0
+
+- Added `startIndex` and `endIndex` to `Query`.
+- `FieldScope.field`, `FieldCompareQuery.field` and `FieldCompareQuery.operator` are now a `TextQuery`.
+- `field:<exp>` and `field <operator> <exp>`: `<exp>` can now be an empty string.
+
 ## 1.6.0
 
 - Upgraded `petitparser` to `5.0.0`.

--- a/lib/query.dart
+++ b/lib/query.dart
@@ -3,9 +3,9 @@ import 'src/grammar.dart';
 
 export 'src/ast.dart';
 
-final _parser = QueryGrammarDefinition().build();
+final _parser = QueryGrammarDefinition().build<Query>();
 
 /// Parses [input] and returns a parsed [Query].
 Query parseQuery(String input) {
-  return _parser.parse(input).value as Query;
+  return _parser.parse(input).value;
 }

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -1,12 +1,12 @@
 /// Base interface for queries.
 abstract class Query {
-  const Query(this.tokenStart, this.tokenEnd);
+  const Query(this.startIndex, this.endIndex);
 
-  /// The start position of the token from the input.
-  final int tokenStart;
+  /// The start index of the token from the input.
+  final int startIndex;
 
-  /// The end position of the token from the input.
-  final int tokenEnd;
+  /// The end index of the token from the input.
+  final int endIndex;
 
   /// Returns a String-representation of this [Query].
   ///
@@ -25,7 +25,7 @@ abstract class Query {
 class TextQuery extends Query {
   final String text;
   final bool isExactMatch;
-  const TextQuery(this.text, super.tokenStart, super.tokenStop,
+  const TextQuery(this.text, super.startIndex, super.endIndex,
       {this.isExactMatch = false});
 
   @override
@@ -37,7 +37,7 @@ class TextQuery extends Query {
 class PhraseQuery extends TextQuery {
   final List<TextQuery> children;
   const PhraseQuery(
-      super.phrase, this.children, super.tokenStart, super.tokenStop)
+      super.phrase, this.children, super.startIndex, super.endIndex)
       : super(isExactMatch: true);
 
   @override
@@ -50,7 +50,7 @@ class FieldScope extends Query {
   final String field;
   final Query child;
 
-  const FieldScope(this.field, this.child, super.tokenStart, super.tokenStop);
+  const FieldScope(this.field, this.child, super.startIndex, super.endIndex);
 
   @override
   String toString({bool debug = false}) =>
@@ -64,7 +64,7 @@ class FieldCompareQuery extends Query {
   final TextQuery text;
 
   const FieldCompareQuery(
-      this.field, this.operator, this.text, super.tokenStart, super.tokenStop);
+      this.field, this.operator, this.text, super.startIndex, super.endIndex);
 
   @override
   String toString({bool debug = false}) =>
@@ -78,7 +78,7 @@ class RangeQuery extends Query {
   final TextQuery end;
   final bool endInclusive;
 
-  const RangeQuery(this.start, this.end, super.tokenStart, super.tokenStop,
+  const RangeQuery(this.start, this.end, super.startIndex, super.endIndex,
       {this.startInclusive = true, this.endInclusive = true});
 
   @override
@@ -95,7 +95,7 @@ class RangeQuery extends Query {
 /// Negates the [child] query. (bool NOT)
 class NotQuery extends Query {
   final Query child;
-  const NotQuery(this.child, super.tokenStart, super.tokenStop);
+  const NotQuery(this.child, super.startIndex, super.endIndex);
 
   @override
   String toString({bool debug = false}) => '-${child.toString(debug: debug)}';
@@ -104,7 +104,7 @@ class NotQuery extends Query {
 /// Groups the [child] query to override implicit precedence.
 class GroupQuery extends Query {
   final Query child;
-  const GroupQuery(this.child, super.tokenStart, super.tokenStop);
+  const GroupQuery(this.child, super.startIndex, super.endIndex);
 
   @override
   String toString({bool debug = false}) => '(${child.toString(debug: debug)})';
@@ -114,7 +114,7 @@ class GroupQuery extends Query {
 class AndQuery extends Query {
   final List<Query> children;
 
-  const AndQuery(this.children, super.tokenStart, super.tokenStop);
+  const AndQuery(this.children, super.startIndex, super.endIndex);
 
   @override
   String toString({bool debug = false}) =>
@@ -125,7 +125,7 @@ class AndQuery extends Query {
 class OrQuery extends Query {
   final List<Query> children;
 
-  const OrQuery(this.children, super.tokenStart, super.tokenStop);
+  const OrQuery(this.children, super.startIndex, super.endIndex);
 
   @override
   String toString({bool debug = false}) =>

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -1,15 +1,25 @@
+/// A class that describes the position of the source text.
+class SourcePosition {
+  const SourcePosition(this.start, this.end);
+
+  /// The start position of this query, exclusive.
+  final int start;
+
+  /// The end position of this query, exclusive.
+  final int end;
+
+  // The length of this query, in characters.
+  int get length => end - start;
+}
+
 /// Base interface for queries.
 abstract class Query {
   const Query({
-    required this.startIndex,
-    required this.endIndex,
+    required this.position,
   });
 
-  /// The start index of the token from the input.
-  final int startIndex;
-
-  /// The end index of the token from the input.
-  final int endIndex;
+  /// The position of this query relative to the source.
+  final SourcePosition position;
 
   /// Returns a String-representation of this [Query].
   ///
@@ -21,6 +31,9 @@ abstract class Query {
   @override
   String toString({bool debug = false});
 
+  /// Returns this [Query] cast as [R]
+  ///
+  /// If the [Query] cannot be cast to [R] it will throw an exception.
   R cast<R extends Query>() => this as R;
 }
 
@@ -33,8 +46,7 @@ class TextQuery extends Query {
   const TextQuery({
     required this.text,
     this.isExactMatch = false,
-    required super.startIndex,
-    required super.endIndex,
+    required super.position,
   });
 
   @override
@@ -48,8 +60,7 @@ class PhraseQuery extends TextQuery {
   const PhraseQuery({
     required super.text,
     required this.children,
-    required super.startIndex,
-    required super.endIndex,
+    required super.position,
   }) : super(isExactMatch: true);
 
   @override
@@ -65,8 +76,7 @@ class FieldScope extends Query {
   const FieldScope({
     required this.field,
     required this.child,
-    required super.startIndex,
-    required super.endIndex,
+    required super.position,
   });
 
   @override
@@ -84,8 +94,7 @@ class FieldCompareQuery extends Query {
     required this.field,
     required this.operator,
     required this.text,
-    required super.startIndex,
-    required super.endIndex,
+    required super.position,
   });
 
   @override
@@ -103,8 +112,7 @@ class RangeQuery extends Query {
   const RangeQuery({
     required this.start,
     required this.end,
-    required super.startIndex,
-    required super.endIndex,
+    required super.position,
     this.startInclusive = true,
     this.endInclusive = true,
   });
@@ -125,8 +133,7 @@ class NotQuery extends Query {
   final Query child;
   const NotQuery({
     required this.child,
-    required super.startIndex,
-    required super.endIndex,
+    required super.position,
   });
 
   @override
@@ -138,8 +145,7 @@ class GroupQuery extends Query {
   final Query child;
   const GroupQuery({
     required this.child,
-    required super.startIndex,
-    required super.endIndex,
+    required super.position,
   });
 
   @override
@@ -152,8 +158,7 @@ class AndQuery extends Query {
 
   const AndQuery({
     required this.children,
-    required super.startIndex,
-    required super.endIndex,
+    required super.position,
   });
 
   @override
@@ -167,8 +172,7 @@ class OrQuery extends Query {
 
   const OrQuery({
     required this.children,
-    required super.startIndex,
-    required super.endIndex,
+    required super.position,
   });
 
   @override

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -47,10 +47,13 @@ class PhraseQuery extends TextQuery {
 
 /// Scopes [child] [Query] to be applied only on the [field].
 class FieldScope extends Query {
-  final String field;
+  final TextQuery fieldText;
   final Query child;
 
-  const FieldScope(this.field, this.child, super.startIndex, super.endIndex);
+  const FieldScope(
+      this.fieldText, this.child, super.startIndex, super.endIndex);
+
+  String get field => fieldText.text;
 
   @override
   String toString({bool debug = false}) =>
@@ -59,12 +62,16 @@ class FieldScope extends Query {
 
 /// Describes a [field] [operator] [text] tripled (e.g. year < 2000).
 class FieldCompareQuery extends Query {
-  final String field;
-  final String operator;
+  final TextQuery fieldText;
+  final TextQuery operatorText;
   final TextQuery text;
 
-  const FieldCompareQuery(
-      this.field, this.operator, this.text, super.startIndex, super.endIndex);
+  const FieldCompareQuery(this.fieldText, this.operatorText, this.text,
+      super.startIndex, super.endIndex);
+
+  String get field => fieldText.text;
+
+  String get operator => operatorText.text;
 
   @override
   String toString({bool debug = false}) =>

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -17,6 +17,8 @@ abstract class Query {
   /// testing unambiguous.
   @override
   String toString({bool debug = false});
+
+  R cast<R extends Query>() => this as R;
 }
 
 /// Text query to match [text].
@@ -47,13 +49,10 @@ class PhraseQuery extends TextQuery {
 
 /// Scopes [child] [Query] to be applied only on the [field].
 class FieldScope extends Query {
-  final TextQuery fieldText;
+  final TextQuery field;
   final Query child;
 
-  const FieldScope(
-      this.fieldText, this.child, super.startIndex, super.endIndex);
-
-  String get field => fieldText.text;
+  const FieldScope(this.field, this.child, super.startIndex, super.endIndex);
 
   @override
   String toString({bool debug = false}) =>
@@ -62,16 +61,12 @@ class FieldScope extends Query {
 
 /// Describes a [field] [operator] [text] tripled (e.g. year < 2000).
 class FieldCompareQuery extends Query {
-  final TextQuery fieldText;
-  final TextQuery operatorText;
+  final TextQuery field;
+  final TextQuery operator;
   final TextQuery text;
 
-  const FieldCompareQuery(this.fieldText, this.operatorText, this.text,
-      super.startIndex, super.endIndex);
-
-  String get field => fieldText.text;
-
-  String get operator => operatorText.text;
+  const FieldCompareQuery(
+      this.field, this.operator, this.text, super.startIndex, super.endIndex);
 
   @override
   String toString({bool debug = false}) =>

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -1,5 +1,13 @@
 /// Base interface for queries.
 abstract class Query {
+  const Query(this.tokenStart, this.tokenEnd);
+
+  /// The start position of the token from the input.
+  final int tokenStart;
+
+  /// The end position of the token from the input.
+  final int tokenEnd;
+
   /// Returns a String-representation of this [Query].
   ///
   /// Implementation should aim to provide a format that can be parsed to the
@@ -14,10 +22,11 @@ abstract class Query {
 /// Text query to match [text].
 ///
 /// [isExactMatch] is set when the [text] was inside quotes.
-class TextQuery implements Query {
+class TextQuery extends Query {
   final String text;
   final bool isExactMatch;
-  TextQuery(this.text, {this.isExactMatch = false});
+  const TextQuery(this.text, super.tokenStart, super.tokenStop,
+      {this.isExactMatch = false});
 
   @override
   String toString({bool debug = false}) =>
@@ -27,7 +36,9 @@ class TextQuery implements Query {
 /// Phrase query to match "[text]" for a list of words inside quotes.
 class PhraseQuery extends TextQuery {
   final List<TextQuery> children;
-  PhraseQuery(String phrase, this.children) : super(phrase, isExactMatch: true);
+  const PhraseQuery(
+      super.phrase, this.children, super.tokenStart, super.tokenStop)
+      : super(isExactMatch: true);
 
   @override
   String toString({bool debug = false}) =>
@@ -35,11 +46,11 @@ class PhraseQuery extends TextQuery {
 }
 
 /// Scopes [child] [Query] to be applied only on the [field].
-class FieldScope implements Query {
+class FieldScope extends Query {
   final String field;
   final Query child;
 
-  FieldScope(this.field, this.child);
+  const FieldScope(this.field, this.child, super.tokenStart, super.tokenStop);
 
   @override
   String toString({bool debug = false}) =>
@@ -47,12 +58,13 @@ class FieldScope implements Query {
 }
 
 /// Describes a [field] [operator] [text] tripled (e.g. year < 2000).
-class FieldCompareQuery implements Query {
+class FieldCompareQuery extends Query {
   final String field;
   final String operator;
   final TextQuery text;
 
-  FieldCompareQuery(this.field, this.operator, this.text);
+  const FieldCompareQuery(
+      this.field, this.operator, this.text, super.tokenStart, super.tokenStop);
 
   @override
   String toString({bool debug = false}) =>
@@ -60,13 +72,13 @@ class FieldCompareQuery implements Query {
 }
 
 /// Describes a range query between [start] and [end].
-class RangeQuery implements Query {
+class RangeQuery extends Query {
   final TextQuery start;
   final bool startInclusive;
   final TextQuery end;
   final bool endInclusive;
 
-  RangeQuery(this.start, this.end,
+  const RangeQuery(this.start, this.end, super.tokenStart, super.tokenStop,
       {this.startInclusive = true, this.endInclusive = true});
 
   @override
@@ -81,28 +93,28 @@ class RangeQuery implements Query {
 }
 
 /// Negates the [child] query. (bool NOT)
-class NotQuery implements Query {
+class NotQuery extends Query {
   final Query child;
-  NotQuery(this.child);
+  const NotQuery(this.child, super.tokenStart, super.tokenStop);
 
   @override
   String toString({bool debug = false}) => '-${child.toString(debug: debug)}';
 }
 
 /// Groups the [child] query to override implicit precedence.
-class GroupQuery implements Query {
+class GroupQuery extends Query {
   final Query child;
-  GroupQuery(this.child);
+  const GroupQuery(this.child, super.tokenStart, super.tokenStop);
 
   @override
   String toString({bool debug = false}) => '(${child.toString(debug: debug)})';
 }
 
 /// Bool AND composition of [children] queries.
-class AndQuery implements Query {
+class AndQuery extends Query {
   final List<Query> children;
 
-  AndQuery(this.children);
+  const AndQuery(this.children, super.tokenStart, super.tokenStop);
 
   @override
   String toString({bool debug = false}) =>
@@ -110,10 +122,10 @@ class AndQuery implements Query {
 }
 
 /// Bool OR composition of [children] queries.
-class OrQuery implements Query {
+class OrQuery extends Query {
   final List<Query> children;
 
-  OrQuery(this.children);
+  const OrQuery(this.children, super.tokenStart, super.tokenStop);
 
   @override
   String toString({bool debug = false}) =>

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -1,6 +1,9 @@
 /// Base interface for queries.
 abstract class Query {
-  const Query(this.startIndex, this.endIndex);
+  const Query({
+    required this.startIndex,
+    required this.endIndex,
+  });
 
   /// The start index of the token from the input.
   final int startIndex;
@@ -27,8 +30,12 @@ abstract class Query {
 class TextQuery extends Query {
   final String text;
   final bool isExactMatch;
-  const TextQuery(this.text, super.startIndex, super.endIndex,
-      {this.isExactMatch = false});
+  const TextQuery({
+    required this.text,
+    this.isExactMatch = false,
+    required super.startIndex,
+    required super.endIndex,
+  });
 
   @override
   String toString({bool debug = false}) =>
@@ -38,9 +45,12 @@ class TextQuery extends Query {
 /// Phrase query to match "[text]" for a list of words inside quotes.
 class PhraseQuery extends TextQuery {
   final List<TextQuery> children;
-  const PhraseQuery(
-      super.phrase, this.children, super.startIndex, super.endIndex)
-      : super(isExactMatch: true);
+  const PhraseQuery({
+    required super.text,
+    required this.children,
+    required super.startIndex,
+    required super.endIndex,
+  }) : super(isExactMatch: true);
 
   @override
   String toString({bool debug = false}) =>
@@ -52,7 +62,12 @@ class FieldScope extends Query {
   final TextQuery field;
   final Query child;
 
-  const FieldScope(this.field, this.child, super.startIndex, super.endIndex);
+  const FieldScope({
+    required this.field,
+    required this.child,
+    required super.startIndex,
+    required super.endIndex,
+  });
 
   @override
   String toString({bool debug = false}) =>
@@ -65,8 +80,13 @@ class FieldCompareQuery extends Query {
   final TextQuery operator;
   final TextQuery text;
 
-  const FieldCompareQuery(
-      this.field, this.operator, this.text, super.startIndex, super.endIndex);
+  const FieldCompareQuery({
+    required this.field,
+    required this.operator,
+    required this.text,
+    required super.startIndex,
+    required super.endIndex,
+  });
 
   @override
   String toString({bool debug = false}) =>
@@ -80,8 +100,14 @@ class RangeQuery extends Query {
   final TextQuery end;
   final bool endInclusive;
 
-  const RangeQuery(this.start, this.end, super.startIndex, super.endIndex,
-      {this.startInclusive = true, this.endInclusive = true});
+  const RangeQuery({
+    required this.start,
+    required this.end,
+    required super.startIndex,
+    required super.endIndex,
+    this.startInclusive = true,
+    this.endInclusive = true,
+  });
 
   @override
   String toString({bool debug = false}) => _debug(
@@ -97,7 +123,11 @@ class RangeQuery extends Query {
 /// Negates the [child] query. (bool NOT)
 class NotQuery extends Query {
   final Query child;
-  const NotQuery(this.child, super.startIndex, super.endIndex);
+  const NotQuery({
+    required this.child,
+    required super.startIndex,
+    required super.endIndex,
+  });
 
   @override
   String toString({bool debug = false}) => '-${child.toString(debug: debug)}';
@@ -106,7 +136,11 @@ class NotQuery extends Query {
 /// Groups the [child] query to override implicit precedence.
 class GroupQuery extends Query {
   final Query child;
-  const GroupQuery(this.child, super.startIndex, super.endIndex);
+  const GroupQuery({
+    required this.child,
+    required super.startIndex,
+    required super.endIndex,
+  });
 
   @override
   String toString({bool debug = false}) => '(${child.toString(debug: debug)})';
@@ -116,7 +150,11 @@ class GroupQuery extends Query {
 class AndQuery extends Query {
   final List<Query> children;
 
-  const AndQuery(this.children, super.startIndex, super.endIndex);
+  const AndQuery({
+    required this.children,
+    required super.startIndex,
+    required super.endIndex,
+  });
 
   @override
   String toString({bool debug = false}) =>
@@ -127,7 +165,11 @@ class AndQuery extends Query {
 class OrQuery extends Query {
   final List<Query> children;
 
-  const OrQuery(this.children, super.startIndex, super.endIndex);
+  const OrQuery({
+    required this.children,
+    required super.startIndex,
+    required super.endIndex,
+  });
 
   @override
   String toString({bool debug = false}) =>

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -38,20 +38,15 @@ abstract class Query {
 }
 
 /// Text query to match [text].
-///
-/// [isExactMatch] is set when the [text] was inside quotes.
 class TextQuery extends Query {
   final String text;
-  final bool isExactMatch;
   const TextQuery({
     required this.text,
-    this.isExactMatch = false,
     required super.position,
   });
 
   @override
-  String toString({bool debug = false}) =>
-      _debug(debug, isExactMatch ? '"$text"' : text);
+  String toString({bool debug = false}) => _debug(debug, text);
 }
 
 /// Phrase query to match "[text]" for a list of words inside quotes.
@@ -61,11 +56,11 @@ class PhraseQuery extends TextQuery {
     required super.text,
     required this.children,
     required super.position,
-  }) : super(isExactMatch: true);
+  });
 
   @override
   String toString({bool debug = false}) =>
-      '"' + children.map((n) => n.toString(debug: debug)).join(' ') + '"';
+      '"${children.map((n) => n.toString(debug: debug)).join(' ')}"';
 }
 
 /// Scopes [child] [Query] to be applied only on the [field].

--- a/lib/src/ast.dart
+++ b/lib/src/ast.dart
@@ -2,7 +2,7 @@
 class SourcePosition {
   const SourcePosition(this.start, this.end);
 
-  /// The start position of this query, exclusive.
+  /// The start position of this query.
   final int start;
 
   /// The end position of this query, exclusive.

--- a/lib/src/grammar.dart
+++ b/lib/src/grammar.dart
@@ -24,7 +24,8 @@ class QueryGrammarDefinition extends GrammarDefinition {
         ...(list.value.last as List).cast<Query>(),
       ];
       if (children.length == 1) return children.single;
-      return AndQuery(children, list.start, list.stop);
+      return AndQuery(
+          children: children, startIndex: list.start, endIndex: list.stop);
     });
   }
 
@@ -48,7 +49,8 @@ class QueryGrammarDefinition extends GrammarDefinition {
             query,
       ];
       if (children.length == 1) return children.single;
-      return OrQuery(children, list.start, list.stop);
+      return OrQuery(
+          children: children, startIndex: list.start, endIndex: list.stop);
     });
   }
 
@@ -60,8 +62,11 @@ class QueryGrammarDefinition extends GrammarDefinition {
         ref0(exclusion).orEmptyTextQuery();
     return g.token().map((list) => list.value.first == null
         ? list.value.last as Query
-        : FieldScope(list.value.first as TextQuery, list.value.last as Query,
-            list.start, list.stop));
+        : FieldScope(
+            field: list.value.first as TextQuery,
+            child: list.value.last as Query,
+            startIndex: list.start,
+            endIndex: list.stop));
   }
 
   // Handles -scope:<exp>
@@ -69,7 +74,10 @@ class QueryGrammarDefinition extends GrammarDefinition {
     final g = exclusionSep().optional() & ref0(scopedExpression);
     return g.token().map((list) => list.value.first == null
         ? list.value.last as Query
-        : NotQuery(list.value.last as Query, list.start, list.stop));
+        : NotQuery(
+            child: list.value.last as Query,
+            startIndex: list.start,
+            endIndex: list.stop));
   }
 
   // Handles -<exp>
@@ -77,7 +85,10 @@ class QueryGrammarDefinition extends GrammarDefinition {
     final g = exclusionSep().optional() & ref0(expression);
     return g.token().map((list) => list.value.first == null
         ? list.value.last as Query
-        : NotQuery(list.value.last as Query, list.start, list.stop));
+        : NotQuery(
+            child: list.value.last as Query,
+            startIndex: list.start,
+            endIndex: list.stop));
   }
 
   Parser expression() =>
@@ -89,8 +100,10 @@ class QueryGrammarDefinition extends GrammarDefinition {
         ref0(root).orEmptyTextQuery() &
         ref0(EXP_SEP).star() &
         char(')');
-    return g.token().map(
-        (list) => GroupQuery(list.value[2] as Query, list.start, list.stop));
+    return g.token().map((list) => GroupQuery(
+        child: list.value[2] as Query,
+        startIndex: list.start,
+        endIndex: list.stop));
   }
 
   Parser<FieldCompareQuery> comparison() {
@@ -100,11 +113,11 @@ class QueryGrammarDefinition extends GrammarDefinition {
         ref0(EXP_SEP).optional() &
         ref0(wordOrExact).orEmptyTextQuery();
     return g.token().map((list) => FieldCompareQuery(
-        list.value[0] as TextQuery,
-        list.value[2] as TextQuery,
-        list.value[4] as TextQuery,
-        list.start,
-        list.stop));
+        field: list.value[0] as TextQuery,
+        operator: list.value[2] as TextQuery,
+        text: list.value[4] as TextQuery,
+        startIndex: list.start,
+        endIndex: list.stop));
   }
 
   Parser<RangeQuery> range() {
@@ -115,12 +128,12 @@ class QueryGrammarDefinition extends GrammarDefinition {
         ref0(rangeSep);
     return g.token().map((list) {
       return RangeQuery(
-          list.value[1] as TextQuery,
-          list.value[3] as TextQuery,
+          start: list.value[1] as TextQuery,
+          end: list.value[3] as TextQuery,
           startInclusive: list.value[0] == '[',
           endInclusive: list.value[4] == ']',
-          list.start,
-          list.stop);
+          startIndex: list.start,
+          endIndex: list.stop);
     });
   }
 
@@ -146,7 +159,11 @@ class QueryGrammarDefinition extends GrammarDefinition {
         children.add(word);
         phrase += '${word.text}$sep';
       }
-      return PhraseQuery(phrase, children, list.start, list.stop);
+      return PhraseQuery(
+          text: phrase,
+          children: children,
+          startIndex: list.start,
+          endIndex: list.stop);
     });
   }
 
@@ -213,12 +230,12 @@ class AnyCharExceptPredicate implements CharacterPredicate {
 }
 
 extension on Parser<String> {
-  Parser<TextQuery> textQuery() =>
-      token().map((str) => TextQuery(str.value, str.start, str.stop));
+  Parser<TextQuery> textQuery() => token().map((str) =>
+      TextQuery(text: str.value, startIndex: str.start, endIndex: str.stop));
 }
 
 extension on Parser<Query?> {
-  Parser<Query> orEmptyTextQuery() => optional()
-      .token()
-      .map((value) => value.value ?? TextQuery('', value.start, value.stop));
+  Parser<Query> orEmptyTextQuery() => optional().token().map((value) =>
+      value.value ??
+      TextQuery(text: '', startIndex: value.start, endIndex: value.stop));
 }

--- a/lib/src/grammar.dart
+++ b/lib/src/grammar.dart
@@ -45,8 +45,10 @@ class QueryGrammarDefinition extends GrammarDefinition {
       if (children.length == 1) return children.single;
       final second = children.last;
       if (children.length == 2 && second is OrQuery) {
-        second.children.insert(0, children.first);
-        return second;
+        return OrQuery([
+          children.first,
+          ...second.children,
+        ], list.start, list.stop);
       }
       return OrQuery(children, list.start, list.stop);
     });

--- a/lib/src/grammar.dart
+++ b/lib/src/grammar.dart
@@ -25,7 +25,7 @@ class QueryGrammarDefinition extends GrammarDefinition {
       ];
       if (children.length == 1) return children.single;
       return AndQuery(
-          children: children, startIndex: list.start, endIndex: list.stop);
+          children: children, position: SourcePosition(list.start, list.stop));
     });
   }
 
@@ -50,7 +50,7 @@ class QueryGrammarDefinition extends GrammarDefinition {
       ];
       if (children.length == 1) return children.single;
       return OrQuery(
-          children: children, startIndex: list.start, endIndex: list.stop);
+          children: children, position: SourcePosition(list.start, list.stop));
     });
   }
 
@@ -65,8 +65,7 @@ class QueryGrammarDefinition extends GrammarDefinition {
         : FieldScope(
             field: list.value.first as TextQuery,
             child: list.value.last as Query,
-            startIndex: list.start,
-            endIndex: list.stop));
+            position: SourcePosition(list.start, list.stop)));
   }
 
   // Handles -scope:<exp>
@@ -76,8 +75,7 @@ class QueryGrammarDefinition extends GrammarDefinition {
         ? list.value.last as Query
         : NotQuery(
             child: list.value.last as Query,
-            startIndex: list.start,
-            endIndex: list.stop));
+            position: SourcePosition(list.start, list.stop)));
   }
 
   // Handles -<exp>
@@ -87,8 +85,7 @@ class QueryGrammarDefinition extends GrammarDefinition {
         ? list.value.last as Query
         : NotQuery(
             child: list.value.last as Query,
-            startIndex: list.start,
-            endIndex: list.stop));
+            position: SourcePosition(list.start, list.stop)));
   }
 
   Parser expression() =>
@@ -102,8 +99,7 @@ class QueryGrammarDefinition extends GrammarDefinition {
         char(')');
     return g.token().map((list) => GroupQuery(
         child: list.value[2] as Query,
-        startIndex: list.start,
-        endIndex: list.stop));
+        position: SourcePosition(list.start, list.stop)));
   }
 
   Parser<FieldCompareQuery> comparison() {
@@ -116,8 +112,7 @@ class QueryGrammarDefinition extends GrammarDefinition {
         field: list.value[0] as TextQuery,
         operator: list.value[2] as TextQuery,
         text: list.value[4] as TextQuery,
-        startIndex: list.start,
-        endIndex: list.stop));
+        position: SourcePosition(list.start, list.stop)));
   }
 
   Parser<RangeQuery> range() {
@@ -132,8 +127,7 @@ class QueryGrammarDefinition extends GrammarDefinition {
           end: list.value[3] as TextQuery,
           startInclusive: list.value[0] == '[',
           endInclusive: list.value[4] == ']',
-          startIndex: list.start,
-          endIndex: list.stop);
+          position: SourcePosition(list.start, list.stop));
     });
   }
 
@@ -162,8 +156,7 @@ class QueryGrammarDefinition extends GrammarDefinition {
       return PhraseQuery(
           text: phrase,
           children: children,
-          startIndex: list.start,
-          endIndex: list.stop);
+          position: SourcePosition(list.start, list.stop));
     });
   }
 
@@ -230,12 +223,12 @@ class AnyCharExceptPredicate implements CharacterPredicate {
 }
 
 extension on Parser<String> {
-  Parser<TextQuery> textQuery() => token().map((str) =>
-      TextQuery(text: str.value, startIndex: str.start, endIndex: str.stop));
+  Parser<TextQuery> textQuery() => token().map((str) => TextQuery(
+      text: str.value, position: SourcePosition(str.start, str.stop)));
 }
 
 extension on Parser<Query?> {
   Parser<Query> orEmptyTextQuery() => optional().token().map((value) =>
       value.value ??
-      TextQuery(text: '', startIndex: value.start, endIndex: value.stop));
+      TextQuery(text: '', position: SourcePosition(value.start, value.stop)));
 }

--- a/lib/src/grammar.dart
+++ b/lib/src/grammar.dart
@@ -33,7 +33,7 @@ class QueryGrammarDefinition extends GrammarDefinition {
 
   // Handles <exp> OR <exp> sequences.
   Parser<Query> or() {
-    final g = (ref0(group) | ref0(scopedExclusion)) &
+    final g = (ref0(group) | ref0(scopedExclusion) | ref0(exclusion)) &
         ((string(' | ') | string(' OR ')) & ref0(root))
             .map((list) => list.last)
             .star();
@@ -56,9 +56,11 @@ class QueryGrammarDefinition extends GrammarDefinition {
 
   // Handles scope:<exp>
   Parser<Query> scopedExpression() {
-    final g =
-        (anyCharExcept(':') & char(':')).optional().map((list) => list?.first) &
-            ref0(exclusion);
+    final g = (anyCharExcept(':') & char(':')).map((list) => list.first) &
+        ref0(exclusion)
+            .optional()
+            .token()
+            .map((str) => str.value ?? TextQuery('', str.start, str.stop));
     return g.token().map((list) => list.value.first == null
         ? list.value.last as Query
         : FieldScope(list.value.first as String, list.value.last as Query,
@@ -103,7 +105,10 @@ class QueryGrammarDefinition extends GrammarDefinition {
         ref0(EXP_SEP).optional() &
         ref0(COMP_OPERATOR) &
         ref0(EXP_SEP).optional() &
-        ref0(wordOrExact);
+        ref0(wordOrExact)
+            .optional()
+            .token()
+            .map((str) => str.value ?? TextQuery('', str.start, str.stop));
     return g.token().map((list) => FieldCompareQuery(
         list.value[0] as String,
         list.value[2] as String,

--- a/lib/src/grammar.dart
+++ b/lib/src/grammar.dart
@@ -40,16 +40,14 @@ class QueryGrammarDefinition extends GrammarDefinition {
     return g.token().map((list) {
       final children = <Query>[
         list.value.first as Query,
-        ...(list.value.last as List).cast<Query>(),
+        for (final query in (list.value.last as List).cast<Query>())
+          // flatten OrQuery children
+          if (query is OrQuery)
+            for (final child in query.children) child
+          else
+            query,
       ];
       if (children.length == 1) return children.single;
-      final second = children.last;
-      if (children.length == 2 && second is OrQuery) {
-        return OrQuery([
-          children.first,
-          ...second.children,
-        ], list.start, list.stop);
-      }
       return OrQuery(children, list.start, list.stop);
     });
   }

--- a/lib/src/grammar.dart
+++ b/lib/src/grammar.dart
@@ -135,20 +135,21 @@ class QueryGrammarDefinition extends GrammarDefinition {
 
   Parser exactWord() => pattern('^" \t\n\r')
       .plus()
+      .flatten()
       .token()
-      .map((str) => TextQuery(str.value.join(), str.start, str.stop));
+      .map((str) => TextQuery(str.value, str.start, str.stop));
 
   Parser exact() {
     final g = char('"') &
-        ref0(EXP_SEP).star() &
-        (ref0(exactWord) & ref0(EXP_SEP).star()).star() &
+        ref0(EXP_SEP).star().flatten() &
+        (ref0(exactWord) & ref0(EXP_SEP).star().flatten()).star() &
         char('"');
     return g.token().map((list) {
       final children = <TextQuery>[];
-      var phrase = list.value[1].join() as String;
+      var phrase = list.value[1] as String;
       for (var w in list.value[2]) {
         final word = w.first as TextQuery;
-        final sep = w[1].join() as String;
+        final sep = w[1] as String;
         children.add(word);
         phrase += '${word.text}$sep';
       }
@@ -160,13 +161,13 @@ class QueryGrammarDefinition extends GrammarDefinition {
 
   Parser<String> WORD_SEP() => whitespace().plus().map((_) => ' ');
 
-  Parser WORD() {
-    final g = allowedChars().plus().map((list) => list.join());
-    return g.token().map((str) => TextQuery(str.value, str.start, str.stop));
-  }
+  Parser WORD() => allowedChars()
+      .plus()
+      .flatten()
+      .token()
+      .map((str) => TextQuery(str.value, str.start, str.stop));
 
-  Parser<String> IDENTIFIER() =>
-      allowedChars().plus().map((list) => list.join());
+  Parser<String> IDENTIFIER() => allowedChars().plus().flatten();
 
   Parser COMP_OPERATOR() =>
       string('<=') |
@@ -205,7 +206,7 @@ Parser<String> anyCharExcept(String except,
     [String message = 'letter or digit expected']) {
   return CharacterParser(AnyCharExceptPredicate(except.codeUnits), message)
       .plus()
-      .map((list) => list.join());
+      .flatten();
 }
 
 class AnyCharExceptPredicate implements CharacterPredicate {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: query
 description: >
   Search query parser to implement customized search.
   Supports boolean groups, field scopes, ranges, comparisons...
-version: 1.6.0
+version: 2.0.0
 homepage: https://github.com/isoos/query
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.6.0
 homepage: https://github.com/isoos/query
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   petitparser: ^5.0.0

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -6,8 +6,8 @@ extension<T extends Query> on T {
   R expect<R extends Query>(String matcher, int start, int end) {
     t.expect(runtimeType, R);
     t.expect(toString(debug: true), matcher);
-    t.expect(startIndex, start);
-    t.expect(endIndex, end);
+    t.expect(position.start, start);
+    t.expect(position.end, end);
     return cast<R>();
   }
 }

--- a/test/query_test.dart
+++ b/test/query_test.dart
@@ -1,198 +1,284 @@
 import 'package:query/query.dart';
 import 'package:test/test.dart';
+import 'package:test/test.dart' as t;
 
-String debugQuery(String input) => parseQuery(input).toString(debug: true);
+extension<T extends Query> on T {
+  R expect<R extends Query>(String matcher, int start, int end) {
+    t.expect(runtimeType, R);
+    t.expect(toString(debug: true), matcher);
+    t.expect(startIndex, start);
+    t.expect(endIndex, end);
+    return cast<R>();
+  }
+}
 
 void main() {
   group('Base expressions', () {
     test('1 string', () {
-      expect(debugQuery('abc'), '<abc>');
-      expect(debugQuery('"abc"'), '"<abc>"');
-      expect(debugQuery('abc*'), '<abc*>');
+      parseQuery('abc').expect<TextQuery>('<abc>', 0, 3);
+      parseQuery('"abc"')
+          .expect<PhraseQuery>('"<abc>"', 0, 5)
+          .children
+          .first
+          .expect<TextQuery>('<abc>', 1, 4);
+      parseQuery('abc*').expect<TextQuery>('<abc*>', 0, 4);
     });
 
     test('2 strings', () {
-      expect(debugQuery('abc def'), '(<abc> <def>)');
-      expect(debugQuery('"abc 1" def'), '("<abc> <1>" <def>)');
-      expect(debugQuery('abc "def 2"'), '(<abc> "<def> <2>")');
-      expect(debugQuery('"abc" "def"'), '("<abc>" "<def>")');
-      expect(debugQuery('"abc 1" "def 2"'), '("<abc> <1>" "<def> <2>")');
+      parseQuery('abc def').expect<AndQuery>('(<abc> <def>)', 0, 7)
+        ..children[0].expect<TextQuery>('<abc>', 0, 3)
+        ..children[1].expect<TextQuery>('<def>', 4, 7);
+      parseQuery('"abc 1" def').expect<AndQuery>('("<abc> <1>" <def>)', 0, 11)
+        ..children[0].expect<PhraseQuery>('"<abc> <1>"', 0, 7)
+        ..children[1].expect<TextQuery>('<def>', 8, 11);
+      parseQuery('abc "def 2"').expect<AndQuery>('(<abc> "<def> <2>")', 0, 11);
+      parseQuery('"abc" "def"').expect<AndQuery>('("<abc>" "<def>")', 0, 11);
+      parseQuery('"abc 1" "def 2"')
+          .expect<AndQuery>('("<abc> <1>" "<def> <2>")', 0, 15);
     });
 
     test('explicit AND', () {
-      expect(debugQuery('a AND b c'), '(<a> <b> <c>)');
+      parseQuery('a AND b c').expect<AndQuery>('(<a> <b> <c>)', 0, 9)
+        ..children[0].expect<TextQuery>('<a>', 0, 1)
+        ..children[1].expect<TextQuery>('<b>', 6, 7)
+        ..children[2].expect<TextQuery>('<c>', 8, 9);
     });
 
     test('negative word', () {
-      expect(debugQuery('-abc'), '-<abc>');
-      expect(debugQuery('-"abc"'), '-"<abc>"');
-      expect(debugQuery('-"abc 1"'), '-"<abc> <1>"');
-
-      expect(debugQuery('NOT abc'), '-<abc>');
-      expect(debugQuery('NOT "abc"'), '-"<abc>"');
-      expect(debugQuery('NOT "abc 1"'), '-"<abc> <1>"');
+      parseQuery('-abc')
+          .expect<NotQuery>('-<abc>', 0, 4)
+          .child
+          .expect<TextQuery>('<abc>', 1, 4);
+      parseQuery('-"abc"')
+          .expect<NotQuery>('-"<abc>"', 0, 6)
+          .child
+          .expect<PhraseQuery>('"<abc>"', 1, 6);
+      parseQuery('-"abc 1"')
+          .expect<NotQuery>('-"<abc> <1>"', 0, 8)
+          .child
+          .expect<PhraseQuery>('"<abc> <1>"', 1, 8)
+          .children
+          .first
+          .expect<TextQuery>('<abc>', 2, 5);
+      parseQuery('NOT abc')
+          .expect<NotQuery>('-<abc>', 0, 7)
+          .child
+          .expect<TextQuery>('<abc>', 4, 7);
+      parseQuery('NOT "abc"').expect<NotQuery>('-"<abc>"', 0, 9);
+      parseQuery('NOT "abc 1"').expect<NotQuery>('-"<abc> <1>"', 0, 11);
     });
 
     test('scoped', () {
-      expect(debugQuery('a:abc'), 'a:<abc>');
-      expect(debugQuery('a:"abc"'), 'a:"<abc>"');
-      expect(debugQuery('a:"abc 1"'), 'a:"<abc> <1>"');
-      expect(debugQuery('a:-"abc 1"'), 'a:-"<abc> <1>"');
-      expect(debugQuery('NOT field:abc'), '-field:<abc>');
+      parseQuery('a:abc').expect<FieldScope>('a:<abc>', 0, 5)
+        ..field.expect<TextQuery>('<a>', 0, 1)
+        ..child.expect<TextQuery>('<abc>', 2, 5);
+      parseQuery('a:"abc"').expect<FieldScope>('a:"<abc>"', 0, 7);
+      parseQuery('a:"abc 1"').expect<FieldScope>('a:"<abc> <1>"', 0, 9);
+      parseQuery('a:-"abc 1"').expect<FieldScope>('a:-"<abc> <1>"', 0, 10);
+      parseQuery('NOT field:abc')
+          .expect<NotQuery>('-field:<abc>', 0, 13)
+          .child
+          .expect<FieldScope>('field:<abc>', 4, 13)
+        ..field.expect<TextQuery>('<field>', 4, 9)
+        ..child.expect<TextQuery>('<abc>', 10, 13);
+      parseQuery('a:').expect<FieldScope>('a:<>', 0, 2);
+      parseQuery('a: AND a').expect<AndQuery>('(a:<> <a>)', 0, 8);
     });
 
     test('special scoped', () {
-      expect(debugQuery('a*:abc'), 'a*:<abc>');
-      expect(debugQuery('a%:"abc"'), 'a%:"<abc>"');
+      parseQuery('a*:abc').expect<FieldScope>('a*:<abc>', 0, 6);
+      parseQuery('a%:"abc"').expect<FieldScope>('a%:"<abc>"', 0, 8);
     });
 
     test('compare', () {
-      expect(debugQuery('year < 2000'), '<year<2000>');
-      expect(debugQuery('field >= "test case"'), '<field>="test case">');
+      parseQuery('year < 2000').expect<FieldCompareQuery>('<year<2000>', 0, 11)
+        ..field.expect<TextQuery>('<year>', 0, 4)
+        ..operator.expect<TextQuery>('<<>', 5, 6)
+        ..text.expect<TextQuery>('<2000>', 7, 11);
+      parseQuery('field >= "test case"')
+          .expect<FieldCompareQuery>('<field>="test case">', 0, 20)
+        ..field.expect<TextQuery>('<field>', 0, 5)
+        ..operator.expect<TextQuery>('<>=>', 6, 8)
+        ..text.expect<PhraseQuery>('"<test> <case>"', 9, 20);
+      parseQuery('year = ').expect<FieldCompareQuery>('<year=>', 0, 7);
     });
 
     test('range', () {
-      expect(debugQuery('[1 TO 10]'), '<[<1> TO <10>]>');
-      expect(debugQuery(']1 TO 10['), '<]<1> TO <10>[>');
-      expect(debugQuery(']"1 a" TO "10 b"['), '<]"<1> <a>" TO "<10> <b>"[>');
+      parseQuery('[1 TO 10]').expect<RangeQuery>('<[<1> TO <10>]>', 0, 9)
+        ..start.expect<TextQuery>('<1>', 1, 2)
+        ..end.expect<TextQuery>('<10>', 6, 8);
+      parseQuery(']1 TO 10[').expect<RangeQuery>('<]<1> TO <10>[>', 0, 9)
+        ..start.expect<TextQuery>('<1>', 1, 2)
+        ..end.expect<TextQuery>('<10>', 6, 8);
+      parseQuery(']"1 a" TO "10 b"[')
+          .expect<RangeQuery>('<]"<1> <a>" TO "<10> <b>"[>', 0, 17)
+        ..start.expect<PhraseQuery>('"<1> <a>"', 1, 6)
+        ..end.expect<PhraseQuery>('"<10> <b>"', 10, 16);
     });
   });
 
   group('or', () {
     test('2 items', () {
-      expect(debugQuery('a OR b'), '(<a> OR <b>)');
+      parseQuery('a OR b').expect<OrQuery>('(<a> OR <b>)', 0, 6)
+        ..children.first.expect<TextQuery>('<a>', 0, 1)
+        ..children.last.expect<TextQuery>('<b>', 5, 6);
     });
 
     test('2 items pipe', () {
-      expect(debugQuery('a | b'), '(<a> OR <b>)');
+      parseQuery('a | b').expect<OrQuery>('(<a> OR <b>)', 0, 5)
+        ..children.first.expect<TextQuery>('<a>', 0, 1)
+        ..children.last.expect<TextQuery>('<b>', 4, 5);
     });
 
     test('3 items', () {
-      expect(debugQuery('a OR b OR c'), '(<a> OR <b> OR <c>)');
+      parseQuery('a OR b OR c').expect<OrQuery>('(<a> OR <b> OR <c>)', 0, 11)
+        ..children[0].expect<TextQuery>('<a>', 0, 1)
+        ..children[1].expect<TextQuery>('<b>', 5, 6)
+        ..children[2].expect<TextQuery>('<c>', 10, 11);
     });
 
     test('3 items pipe', () {
-      expect(debugQuery('a | b | c'), '(<a> OR <b> OR <c>)');
+      parseQuery('a | b | c').expect<OrQuery>('(<a> OR <b> OR <c>)', 0, 9)
+        ..children[0].expect<TextQuery>('<a>', 0, 1)
+        ..children[1].expect<TextQuery>('<b>', 4, 5)
+        ..children[2].expect<TextQuery>('<c>', 8, 9);
     });
 
     test('3 items pipe mixed', () {
-      expect(debugQuery('a OR b | c'), '(<a> OR <b> OR <c>)');
-      expect(debugQuery('a | b OR c'), '(<a> OR <b> OR <c>)');
+      parseQuery('a OR b | c').expect<OrQuery>('(<a> OR <b> OR <c>)', 0, 10)
+        ..children[0].expect<TextQuery>('<a>', 0, 1)
+        ..children[1].expect<TextQuery>('<b>', 5, 6)
+        ..children[2].expect<TextQuery>('<c>', 9, 10);
+      parseQuery('a | b OR c').expect<OrQuery>('(<a> OR <b> OR <c>)', 0, 10)
+        ..children[0].expect<TextQuery>('<a>', 0, 1)
+        ..children[1].expect<TextQuery>('<b>', 4, 5)
+        ..children[2].expect<TextQuery>('<c>', 9, 10);
     });
 
     test('precedence of implicit AND, explicit OR', () {
-      expect(debugQuery('a b OR c'), '(<a> (<b> OR <c>))');
-      expect(debugQuery('a OR b c'), '(<a> OR (<b> <c>))');
-      expect(debugQuery('a OR b c OR d'), '(<a> OR (<b> (<c> OR <d>)))');
+      parseQuery('a b OR c').expect<AndQuery>('(<a> (<b> OR <c>))', 0, 8);
+      parseQuery('a OR b c').expect<OrQuery>('(<a> OR (<b> <c>))', 0, 8);
+      parseQuery('a OR b c OR d')
+          .expect<OrQuery>('(<a> OR (<b> (<c> OR <d>)))', 0, 13);
     });
 
     test('precedence of implicit AND, explicit OR pipe', () {
-      expect(debugQuery('a b | c'), '(<a> (<b> OR <c>))');
-      expect(debugQuery('a | b c'), '(<a> OR (<b> <c>))');
-      expect(debugQuery('a | b c | d'), '(<a> OR (<b> (<c> OR <d>)))');
+      parseQuery('a b | c').expect<AndQuery>('(<a> (<b> OR <c>))', 0, 7);
+      parseQuery('a | b c').expect<OrQuery>('(<a> OR (<b> <c>))', 0, 7);
+      parseQuery('a | b c | d')
+          .expect<OrQuery>('(<a> OR (<b> (<c> OR <d>)))', 0, 11);
     });
   });
 
   group('complex cases', () {
     test('#1', () {
-      expect(debugQuery('a:-v1 b:(beta OR moon < Deimos OR [a TO e])'),
-          '(a:-<v1> b:((<beta> OR <moon<Deimos> OR <[<a> TO <e>]>)))');
+      parseQuery('a:-v1 b:(beta OR moon < Deimos OR [a TO e])')
+          .expect<AndQuery>(
+              '(a:-<v1> b:((<beta> OR <moon<Deimos> OR <[<a> TO <e>]>)))',
+              0,
+              43);
     });
 
     test('#2', () {
-      expect(debugQuery('a = 2000 b > 2000 c'), '(<a=2000> <b>2000> <c>)');
+      parseQuery('a = 2000 b > 2000 c')
+          .expect<AndQuery>('(<a=2000> <b>2000> <c>)', 0, 19);
     });
 
     test('#3', () {
-      // TODO: fix
-      // expect(debugQuery('(f:abc)'), '');
+      parseQuery('(f:abc)').expect<GroupQuery>('(f:<abc>)', 0, 7);
     });
   });
 
   group('unicode chars', () {
     test('hungarian', () {
-      expect(
-          debugQuery('árvíztűrő TÜKÖRFÚRÓGÉP'), '(<árvíztűrő> <TÜKÖRFÚRÓGÉP>)');
+      parseQuery('árvíztűrő TÜKÖRFÚRÓGÉP')
+          .expect<AndQuery>('(<árvíztűrő> <TÜKÖRFÚRÓGÉP>)', 0, 22);
     });
   });
 
   group('grouping precedence', () {
     test('empty group', () {
-      expect(debugQuery('()'), '(<>)');
+      parseQuery('()').expect<GroupQuery>('(<>)', 0, 2);
     });
     test('empty group with space', () {
-      expect(debugQuery('(  )'), '(<>)');
+      parseQuery('(  )').expect<GroupQuery>('(<>)', 0, 4);
     });
     test('single item group', () {
-      expect(debugQuery('(a)'), '(<a>)');
+      parseQuery('(a)').expect<GroupQuery>('(<a>)', 0, 3);
     });
     test('single item group with space', () {
-      expect(debugQuery('( a )'), '(<a>)');
+      parseQuery('( a )').expect<GroupQuery>('(<a>)', 0, 5);
     });
     test('grouping with two items implicit AND', () {
-      expect(debugQuery('(a b)'), '((<a> <b>))');
+      parseQuery('(a b)').expect<GroupQuery>('((<a> <b>))', 0, 5);
     });
     test('grouping with two items explicit AND', () {
-      expect(debugQuery('(a AND b)'), '((<a> <b>))');
+      parseQuery('(a AND b)').expect<GroupQuery>('((<a> <b>))', 0, 9);
     });
     test('grouping with multiple items', () {
-      expect(debugQuery('(a | b) c (d | e)'),
-          '(((<a> OR <b>)) <c> ((<d> OR <e>)))');
+      parseQuery('(a | b) c (d | e)')
+          .expect<AndQuery>('(((<a> OR <b>)) <c> ((<d> OR <e>)))', 0, 17);
     });
     test('nested grouping', () {
-      expect(debugQuery('(a OR b) OR c'), '(((<a> OR <b>)) OR <c>)');
-      expect(debugQuery('(a OR b) c'), '(((<a> OR <b>)) <c>)');
-      expect(debugQuery('((a OR b) c) | d'), '(((((<a> OR <b>)) <c>)) OR <d>)');
+      parseQuery('(a OR b) OR c')
+          .expect<OrQuery>('(((<a> OR <b>)) OR <c>)', 0, 13);
+      parseQuery('(a OR b) c').expect<AndQuery>('(((<a> OR <b>)) <c>)', 0, 10);
+      parseQuery('((a OR b) c) | d')
+          .expect<OrQuery>('(((((<a> OR <b>)) <c>)) OR <d>)', 0, 16);
     });
     test('negative grouping', () {
-      expect(debugQuery('-(a OR b) OR c'), '(-((<a> OR <b>)) OR <c>)');
-      expect(debugQuery('(a OR -b) c'), '(((<a> OR -<b>)) <c>)');
-      expect(debugQuery('-(-(a OR -b) -c) | -(d)'),
-          '(-((-((<a> OR -<b>)) -<c>)) OR -(<d>))');
+      parseQuery('-(a OR b) OR c')
+          .expect<OrQuery>('(-((<a> OR <b>)) OR <c>)', 0, 14);
+      parseQuery('(a OR -b) c')
+          .expect<AndQuery>('(((<a> OR -<b>)) <c>)', 0, 11);
+      parseQuery('-(-(a OR -b) -c) | -(d)')
+          .expect<OrQuery>('(-((-((<a> OR -<b>)) -<c>)) OR -(<d>))', 0, 23);
     });
     test('scoped grouping', () {
-      expect(debugQuery('(field:abc)'), '(field:<abc>)');
-      expect(debugQuery('(field:abc AND field:def)'),
-          '((field:<abc> field:<def>))');
-      expect(debugQuery('(field:abc OR field:def)'),
-          '((field:<abc> OR field:<def>))');
+      parseQuery('(field:abc)').expect<GroupQuery>('(field:<abc>)', 0, 11);
+      parseQuery('(field:abc AND field:def)')
+          .expect<GroupQuery>('((field:<abc> field:<def>))', 0, 25);
+      parseQuery('(field:abc OR field:def)')
+          .expect<GroupQuery>('((field:<abc> OR field:<def>))', 0, 24);
     });
   });
 
   group('phrase match', () {
     test('empty phrase', () {
-      expect(debugQuery('""'), '""');
+      parseQuery('""').expect<PhraseQuery>('""', 0, 2);
     });
     test('empty phrase with space', () {
-      expect(debugQuery('"  "'), '""');
+      parseQuery('"  "').expect<PhraseQuery>('""', 0, 4);
     });
     test('simple word phrase', () {
-      expect(debugQuery('"a"'), '"<a>"');
+      parseQuery('"a"').expect<PhraseQuery>('"<a>"', 0, 3);
     });
     test('single word phrase with space', () {
-      expect(debugQuery('" a "'), '"<a>"');
+      parseQuery('" a "').expect<PhraseQuery>('"<a>"', 0, 5);
     });
     test('two word phrase', () {
-      expect(debugQuery('"a b"'), '"<a> <b>"');
+      parseQuery('"a b"').expect<PhraseQuery>('"<a> <b>"', 0, 5);
     });
     test('three word phrase', () {
-      expect(debugQuery('"a b c"'), '"<a> <b> <c>"');
+      parseQuery('"a b c"').expect<PhraseQuery>('"<a> <b> <c>"', 0, 7);
     });
     test('three word phrase with AND', () {
-      expect(debugQuery('"a AND b"'), '"<a> <AND> <b>"');
+      parseQuery('"a AND b"').expect<PhraseQuery>('"<a> <AND> <b>"', 0, 9);
     });
     test('three word phrase with OR', () {
-      expect(debugQuery('"a OR b"'), '"<a> <OR> <b>"');
+      parseQuery('"a OR b"').expect<PhraseQuery>('"<a> <OR> <b>"', 0, 8);
     });
     test('negative phrase grouping', () {
-      expect(debugQuery('-("a OR b") OR c'), '(-("<a> <OR> <b>") OR <c>)');
-      expect(debugQuery('(a OR -"b") ("c")'), '(((<a> OR -"<b>")) ("<c>"))');
-      expect(debugQuery('-(-"a OR -b" -c) | -"d"'),
-          '(-((-"<a> <OR> <-b>" -<c>)) OR -"<d>")');
+      parseQuery('-("a OR b") OR c')
+          .expect<OrQuery>('(-("<a> <OR> <b>") OR <c>)', 0, 16);
+      parseQuery('(a OR -"b") ("c")')
+          .expect<AndQuery>('(((<a> OR -"<b>")) ("<c>"))', 0, 17);
+      parseQuery('-(-"a OR -b" -c) | -"d"')
+          .expect<OrQuery>('(-((-"<a> <OR> <-b>" -<c>)) OR -"<d>")', 0, 23);
     });
     test('phrase with parenthesis', () {
-      expect(debugQuery('"(a OR -b)" -("-c | []")'),
-          '("<(a> <OR> <-b)>" -("<-c> <|> <[]>"))');
+      parseQuery('"(a OR -b)" -("-c | []")')
+          .expect<AndQuery>('("<(a> <OR> <-b)>" -("<-c> <|> <[]>"))', 0, 24);
     });
   });
 }


### PR DESCRIPTION
I wanted to be able to offer auto complete suggestions for my search query and for that I needed to know the location of the `Query` to figure out if it was at my cursor position.

This PR adds the start / end position of the `Query` relative to `input`.